### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/examples/ecosystem/docker-compose/redis-standalone/docker-compose.yml
+++ b/examples/ecosystem/docker-compose/redis-standalone/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   redis-standalone:
-    image: "bitnami/redis:6.2.6"
+    image: "soldevelo/redis:6.2.16"
     container_name: redis-standalone
     environment:
       - REDIS_PORT_NUMBER=6379


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/redis:6.2.6` → [`soldevelo/redis:6.2.16`](https://hub.docker.com/r/soldevelo/redis)